### PR TITLE
download_weights: Use destination for tempdir

### DIFF
--- a/scripts/download_weights.py
+++ b/scripts/download_weights.py
@@ -50,7 +50,7 @@ def download_weights(output_dir, fast_model, hf_transfer):
                 # copy instead of mv to avoid destroying huggingface cache
                 shutil.copy2(out_path, local_file_path)
             else:
-                with tempfile.TemporaryDirectory() as tmp_dir:
+                with tempfile.TemporaryDirectory(dir=output_dir) as tmp_dir:
                     snapshot_download(
                         repo_id=repo_id,
                         allow_patterns=[f"*{remote_path}*"],


### PR DESCRIPTION
There is no guarantee that the default tempfile location (usually /tmp) will have sufficient space to contain the downloaded model files before they are moved into their final location. Use the output_dir location to hold the temporary files, which will ensure that only the destination directory's space (or lack thereof) applies when checking for availability.